### PR TITLE
Refactor Menu component to use Element for links and improve structure

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -2,9 +2,8 @@
 import type { HTMLAttributes } from 'astro/types'
 import Element from 'fulldev-ui/components/Element.astro'
 import Heading from 'fulldev-ui/components/Heading.astro'
-import type Link from 'fulldev-ui/components/Link.astro'
+import Link from 'fulldev-ui/components/Link.astro'
 import type { ComponentProps } from 'svelte'
-import Links from './Links.astro'
 
 interface Props extends HTMLAttributes<'div'> {
   size?: 'sm' | 'md' | 'lg' | undefined
@@ -17,6 +16,7 @@ const { size = 'md', heading, links, ...rest } = Astro.props
 
 <Element
   class:list="menu"
+  as="menu"
   {...rest}
 >
   {
@@ -28,10 +28,16 @@ const { size = 'md', heading, links, ...rest } = Astro.props
       />
     )
   }
-  <Links
-    {size}
-    {links}
-  />
+  {
+    links?.map((link) => (
+      <Element as="li">
+        <Link
+          {size}
+          {...link}
+        />
+      </Element>
+    ))
+  }
 </Element>
 
 <style is:global>


### PR DESCRIPTION
- Changed the import of Link from type to a direct import.
- Updated the Menu component to render links as list items using Element.
- Added 'as="menu"' attribute to the Element for semantic HTML.

