### PR TITLE
Add `Tooltip` component to main branch

### DIFF
--- a/src/components/Tooltip.astro
+++ b/src/components/Tooltip.astro
@@ -14,15 +14,15 @@ const transitionClasses = isTransition ? 'transition' : ''
 const placementClasses = (() => {
   switch (placement) {
     case 'top':
-      return 'bottom-full'
+      return 'placeTop'
     case 'right':
-      return 'left-full top-0'
+      return 'placeRight'
     case 'left':
-      return 'right-full top-0'
+      return 'placeLeft'
     case 'bottom':
-      return ''
+      return 'placeBottom'
     default:
-      return ''
+      return 'placeBottom'
   }
 })()
 ---
@@ -41,10 +41,43 @@ const placementClasses = (() => {
 <style is:global>
   @layer fulldev {
     .tooltip {
-      @apply group relative max-w-xs;
+      position: relative;
+
+      &:hover {
+        .tooltip-text {
+          opacity: 1;
+        }
+      }
 
       .tooltip-text {
-        @apply absolute z-10 w-full rounded border px-3 py-1.5 text-center text-sm opacity-0 shadow-sm group-hover:opacity-100;
+        position: absolute;
+        opacity: 0;
+        z-index: 10;
+        border-width: 1px;
+        border-radius: 12px;
+        /* padding: var(--space-4) var(--space-8); */
+        padding: 6px 12px;
+        width: 100%;
+      }
+
+      /* presets */
+      .placeTop {
+        bottom: 120%;
+      }
+      .placeRight {
+        top: 0;
+        left: 120%;
+      }
+      .placeLeft {
+        top: 0;
+        right: 120%;
+      }
+      .placeBottom {
+        top: 120%;
+      }
+      .transition {
+        /* transition: var(--transition); */
+        transition: all 150ms ease-in-out;
       }
     }
   }

--- a/src/components/Tooltip.astro
+++ b/src/components/Tooltip.astro
@@ -1,0 +1,51 @@
+---
+import type { HTMLAttributes } from 'astro/types'
+import Element from 'fulldev-ui/components/Element.astro'
+
+interface Props extends HTMLAttributes<'div'> {
+  isTransition?: boolean | undefined
+  text?: string | undefined
+  placement?: 'top' | 'right' | 'bottom' | 'left' | undefined
+}
+
+const { isTransition = true, text, placement = 'bottom', ...rest } = Astro.props
+
+const transitonClasses = isTransition ? 'transition' : ''
+const placementClasses = (() => {
+  switch (placement) {
+    case 'top':
+      return 'bottom-full'
+    case 'right':
+      return 'left-full top-0'
+    case 'left':
+      return 'right-full top-0'
+    case 'bottom':
+      return ''
+    default:
+      return ''
+  }
+})()
+---
+
+<Element
+  class="tooltip"
+  {...rest}
+>
+  <slot />
+
+  <aside class:list={['tooltip-text', transitonClasses, placementClasses]}>
+    {text}
+  </aside>
+</Element>
+
+<style is:global>
+  @layer fulldev {
+    .tooltip {
+      @apply group relative max-w-xs;
+
+      .tooltip-text {
+        @apply absolute z-10 w-full rounded border px-3 py-1.5 text-center text-sm opacity-0 shadow-sm group-hover:opacity-100;
+      }
+    }
+  }
+</style>

--- a/src/components/Tooltip.astro
+++ b/src/components/Tooltip.astro
@@ -10,7 +10,7 @@ interface Props extends HTMLAttributes<'div'> {
 
 const { isTransition = true, text, placement = 'bottom', ...rest } = Astro.props
 
-const transitonClasses = isTransition ? 'transition' : ''
+const transitionClasses = isTransition ? 'transition' : ''
 const placementClasses = (() => {
   switch (placement) {
     case 'top':
@@ -33,7 +33,7 @@ const placementClasses = (() => {
 >
   <slot />
 
-  <aside class:list={['tooltip-text', transitonClasses, placementClasses]}>
+  <aside class:list={['tooltip-text', transitionClasses, placementClasses]}>
     {text}
   </aside>
 </Element>


### PR DESCRIPTION
Hello, fulldev team.

I found the Tooltip component hasn't been added. 

![showcase](https://github.com/user-attachments/assets/d062ca8e-746f-433e-a71b-6c4aa5a73d41)

I created this component after I viewed and learned the code style of the relevant components that already exist in the main branch.

The `Tooltip.astro` component has 3 props that can be injected, as the code below:

```ts
interface Props extends HTMLAttributes<'div'> {
  isTransition?: boolean | undefined
  text?: string | undefined
  placement?: 'top' | 'right' | 'bottom' | 'left' | undefined
}
```

I did not find the tailwindcss `cn` function from the utils folder, so I can't use this function to judge whether this component should add a transition or set the placement, so I achieve this functionality by using the code below:

```ts
const transitonClasses = isTransition ? 'transition' : ''
const placementClasses = (() => {
  switch (placement) {
    case 'top':
      return 'bottom-full'
    case 'right':
      return 'left-full top-0'
    case 'left':
      return 'right-full top-0'
    case 'bottom':
      return ''
    default:
      return ''
  }
})()
```
And add the `transitionClasses` and `placementClasses` to `class:list` by using the code below:

```html
<Element
  class="tooltip"
  {...rest}
>
  <slot />

  <aside class:list={['tooltip-text', transitonClasses, placementClasses]}>
    {text}
  </aside>
</Element>
```

This component has passed a simple test on my local Astro project, and I hope it will be helpful.

