### PR TITLE
Add more content to Install instructions

### DIFF
--- a/src/content/pages/docs/installation.mdx
+++ b/src/content/pages/docs/installation.mdx
@@ -5,23 +5,43 @@ title: Installation
 
 import Link from 'fulldev-ui/components/Link.astro'
 
-You can install fulldev-ui using `astro add`, or install it manually.
+You can install fulldev-ui using Astro's integration setup, or install it manually.
 
-## Install with `astro add`
+## Automatic Integration Setup
 
-In your project, run the following command to add the integration.
+Run any of the following commands to add the fulldev-ui integration automatically.
 
 ```bash
+# 
 npx astro add fulldev-ui
+# or
+pnpm astro add fulldev-ui
+# or
+yarn astro add fulldev-ui
+# or
+bunx astro add fulldev-ui
 ```
 
-Type `y` to install the fulldev-ui package, and type `y` again to add the integration to your Astro config file.
+Type `y` at the prompts to add fulldev-ui to your dependencies and
+add the integration to your Astro configuration file.
 
 ```bash
-TODO
+  Astro will make the following changes to your config file:
+
+ ╭ astro.config.mjs ─────────────────────────────╮
+ │ // @ts-check                                  │
+ │ import { defineConfig } from 'astro/config';  │
+ │                                               │
+ │ import fulldevUi from 'fulldev-ui';           │
+ │                                               │
+ │ // https://astro.build/config                 │
+ │ export default defineConfig({                 │
+ │   integrations: [fulldevUi()]                 │
+ │ });                                           │
+ ╰───────────────────────────────────────────────╯
 ```
 
-## Install manually
+## Manual installation
 
 Run any of the following commands to add fulldev-ui to your dependencies.
 

--- a/src/content/pages/docs/installation.mdx
+++ b/src/content/pages/docs/installation.mdx
@@ -5,6 +5,24 @@ title: Installation
 
 import Link from 'fulldev-ui/components/Link.astro'
 
+You can install fulldev-ui using `astro add`, or install it manually.
+
+## Install with `astro add`
+
+In your project, run the following command to add the integration.
+
+```bash
+npx astro add fulldev-ui
+```
+
+Type `y` to install the fulldev-ui package, and type `y` again to add the integration to your Astro config file.
+
+```bash
+TODO
+```
+
+## Install manually
+
 Run any of the following commands to add fulldev-ui to your dependencies.
 
 ```bash

--- a/src/content/pages/docs/installation.mdx
+++ b/src/content/pages/docs/installation.mdx
@@ -12,7 +12,6 @@ You can install fulldev-ui using Astro's integration setup, or install it manual
 Run any of the following commands to add the fulldev-ui integration automatically.
 
 ```bash
-# 
 npx astro add fulldev-ui
 # or
 pnpm astro add fulldev-ui
@@ -39,6 +38,8 @@ add the integration to your Astro configuration file.
  │   integrations: [fulldevUi()]                 │
  │ });                                           │
  ╰───────────────────────────────────────────────╯
+
+? Continue? » (Y/n)
 ```
 
 ## Manual installation

--- a/src/content/pages/docs/installation.mdx
+++ b/src/content/pages/docs/installation.mdx
@@ -21,26 +21,7 @@ yarn astro add fulldev-ui
 bunx astro add fulldev-ui
 ```
 
-Type `y` at the prompts to add fulldev-ui to your dependencies and
-add the integration to your Astro configuration file.
-
-```bash
-  Astro will make the following changes to your config file:
-
- ╭ astro.config.mjs ─────────────────────────────╮
- │ // @ts-check                                  │
- │ import { defineConfig } from 'astro/config';  │
- │                                               │
- │ import fulldevUi from 'fulldev-ui';           │
- │                                               │
- │ // https://astro.build/config                 │
- │ export default defineConfig({                 │
- │   integrations: [fulldevUi()]                 │
- │ });                                           │
- ╰───────────────────────────────────────────────╯
-
-? Continue? » (Y/n)
-```
+Type `y` at the prompts for Astro to install dependencies and add the integration.
 
 ## Manual installation
 
@@ -56,7 +37,10 @@ yarn add fulldev-ui
 bun add fulldev-ui
 ```
 
-Add the integration to your `astro.config.ts` file.
+Add the integration to your `astro.config.ts` file:
+
+1. Add `import fulldev from 'fulldev-ui/integration'` to the list of imports.
+2. Add `fulldev({})` to the integrations list.
 
 ```ts
 // astro.config.ts
@@ -64,6 +48,6 @@ import { defineConfig } from 'astro/config'
 import fulldev from 'fulldev-ui/integration'
 
 export default defineConfig({
-  integrations: [fulldev()],
+  integrations: [fulldev({})],
 })
 ```


### PR DESCRIPTION
This PR adds more content to the Installation guide:

- Instructions to add the fulldev-ui integration using `astro add`
- Exact steps to add the integration manually, including the use of curly brackets to avoid TS errors