### PR TITLE
feat: add bluesky to Social component

### DIFF
--- a/src/components/Social.astro
+++ b/src/components/Social.astro
@@ -24,6 +24,7 @@ const platform = () => {
   if (href.includes('twitch')) return 'brand-twitch'
   if (href.includes('github')) return 'brand-github'
   if (href.includes('discord')) return 'brand-discord'
+  if (href.includes('bsky.app')) return 'brand-bluesky'
   return undefined
 }
 ---


### PR DESCRIPTION
Adding support for [Bluesky](https://bsky.app) to the Social component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved platform detection to recognize and identify "bsky.app" URLs as "Bluesky".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->