### PR TITLE
feat(accordion): close #152 add height transition

### DIFF
--- a/src/components/ui/accordion/accordion-content.astro
+++ b/src/components/ui/accordion/accordion-content.astro
@@ -14,7 +14,11 @@ const slot = await Astro.slots.render("default")
   slot?.trim().length > 0 && (
     <div
       data-slot="accordion-content"
-      class={cn("overflow-hidden text-sm", "pt-0 pb-4", className)}
+      class={cn(
+        "text-sm",
+        "pt-0 pb-4",
+        className
+      )}
       {...props}
     >
       <Fragment set:html={slot} />

--- a/src/components/ui/accordion/accordion-item.astro
+++ b/src/components/ui/accordion/accordion-item.astro
@@ -17,7 +17,17 @@ const slot = await Astro.slots.render("default")
   slot?.trim().length > 0 && (
     <details
       data-slot="accordion-item"
-      class={cn("border-b last:border-b-0", "group", className)}
+      class={cn(
+        "border-b last:border-b-0",
+        "group",
+        "details-content:h-0 open:details-content:h-auto",
+        "details-content:ease-out",
+        "details-content:duration-200",
+        "details-content:overflow-hidden",
+        "details-content:transition-discrete",
+        "details-content:transition-[height,content-visibility]",
+        className
+      )}
       open={open}
       {...props}
     >
@@ -25,3 +35,4 @@ const slot = await Astro.slots.render("default")
     </details>
   )
 }
+

--- a/src/components/ui/accordion/accordion.astro
+++ b/src/components/ui/accordion/accordion.astro
@@ -12,7 +12,11 @@ const slot = await Astro.slots.render("default")
 
 {
   slot?.trim().length > 0 && (
-    <div data-slot="accordion" class={cn("w-full", className)} {...props}>
+    <div
+      data-slot="accordion"
+      class={cn("w-full [interpolate-size:allow-keywords]", className)}
+      {...props}
+    >
       <Fragment set:html={slot} />
     </div>
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved accordion component animations with enhanced height transitions for smoother open and close interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves accordion open/close animations with height-based transitions using CSS utilities.
> 
> - `accordion-content.astro`: adds `h-0 group-open:h-auto` and `duration-200 ease-out` for smooth height expansion/collapse
> - `accordion-item.astro`: adds `details-content:*` transition utilities including `transition-[height,content-visibility]` and `[interpolate-size:allow-keywords]`
> - `accordion.astro`: no functional changes (formatting only)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2859eebabffbdf5fdf3660548c2430cfa434184. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->