### PR TITLE
fix(field): Add type attribute to Input components

### DIFF
--- a/src/content/docs/docs/components/field.mdx
+++ b/src/content/docs/docs/components/field.mdx
@@ -23,12 +23,12 @@ import { Input } from "@/components/ui/input"
   <FieldGroup>
     <Field>
       <FieldLabel for="name">Full name</FieldLabel>
-      <Input id="name" placeholder="Evil Rabbit" />
+      <Input type="text" id="name" placeholder="Evil Rabbit" />
       <FieldDescription>This appears on invoices and emails.</FieldDescription>
     </Field>
     <Field>
       <FieldLabel for="username">Username</FieldLabel>
-      <Input id="username" placeholder="evilrabbit" />
+      <Input type="text" id="username" placeholder="evilrabbit" />
     </Field>
     <Field orientation="horizontal">
       <Checkbox id="newsletter" />


### PR DESCRIPTION
I imagine that the `Field` example was copied from `shadcn/ui`, which doesn't require a `type` attribute for `Input` components. However `fulldev/input` does require one so I changed it in the docs