### PR TITLE
feat: enable clickable parent menu items with dropdowns

### DIFF
--- a/src/components/blocks/header-1.astro
+++ b/src/components/blocks/header-1.astro
@@ -71,7 +71,10 @@ const desktopMenuItemClass =
           <NavigationMenuItem value={`menu-${index}`}>
             {menu.links && menu.links.length > 0 ? (
               <>
-                <NavigationMenuTrigger class={desktopMenuItemClass}>
+                <NavigationMenuTrigger
+                  class={desktopMenuItemClass}
+                  href={menu.href}
+                >
                   {menu.text}
                 </NavigationMenuTrigger>
                 <NavigationMenuContent>
@@ -87,10 +90,7 @@ const desktopMenuItemClass =
                 </NavigationMenuContent>
               </>
             ) : (
-              <NavigationMenuLink
-                class={desktopMenuItemClass}
-                href={menu.href}
-              >
+              <NavigationMenuLink class={desktopMenuItemClass} href={menu.href}>
                 {menu.text}
               </NavigationMenuLink>
             )}
@@ -146,14 +146,17 @@ const desktopMenuItemClass =
               {menu.links && menu.links.length > 0 ? (
                 <Collapsible class="group">
                   <CollapsibleTrigger>
-                    <SidebarMenuButton
-                      as="div"
-                      class="h-10 rounded-md text-xl"
-                    >
-                      <span class="truncate">{menu.text}</span>
+                    <SidebarMenuButton as="div" class="h-10 rounded-md text-xl">
+                      {menu.href ? (
+                        <a class="truncate" href={menu.href}>
+                          {menu.text}
+                        </a>
+                      ) : (
+                        <span class="truncate">{menu.text}</span>
+                      )}
                       <Icon
                         name="chevron-down"
-                        class="ml-auto text-muted-foreground transition-transform duration-200 ease-out group-open:rotate-180"
+                        class="text-muted-foreground ml-auto transition-transform duration-200 ease-out group-open:rotate-180"
                         aria-hidden="true"
                       />
                     </SidebarMenuButton>

--- a/src/components/blocks/header-2.astro
+++ b/src/components/blocks/header-2.astro
@@ -71,7 +71,10 @@ const desktopMenuItemClass =
           <NavigationMenuItem value={`menu-${index}`}>
             {menu.links && menu.links.length > 0 ? (
               <>
-                <NavigationMenuTrigger class={desktopMenuItemClass}>
+                <NavigationMenuTrigger
+                  class={desktopMenuItemClass}
+                  href={menu.href}
+                >
                   {menu.text}
                 </NavigationMenuTrigger>
                 <NavigationMenuContent>
@@ -87,10 +90,7 @@ const desktopMenuItemClass =
                 </NavigationMenuContent>
               </>
             ) : (
-              <NavigationMenuLink
-                class={desktopMenuItemClass}
-                href={menu.href}
-              >
+              <NavigationMenuLink class={desktopMenuItemClass} href={menu.href}>
                 {menu.text}
               </NavigationMenuLink>
             )}
@@ -144,11 +144,17 @@ const desktopMenuItemClass =
               {menu.links && menu.links.length > 0 ? (
                 <Collapsible class="group">
                   <CollapsibleTrigger>
-                    <SidebarMenuButton as="div" class="h-10 w-full rounded-md text-xl">
-                      <span class="truncate">{menu.text}</span>
+                    <SidebarMenuButton as="div" class="h-10 rounded-md text-xl">
+                      {menu.href ? (
+                        <a class="truncate" href={menu.href}>
+                          {menu.text}
+                        </a>
+                      ) : (
+                        <span class="truncate">{menu.text}</span>
+                      )}
                       <Icon
                         name="chevron-down"
-                        class="ml-auto text-muted-foreground transition-transform duration-200 ease-out group-open:rotate-180"
+                        class="text-muted-foreground ml-auto transition-transform duration-200 ease-out group-open:rotate-180"
                         aria-hidden="true"
                       />
                     </SidebarMenuButton>

--- a/src/components/blocks/header-3.astro
+++ b/src/components/blocks/header-3.astro
@@ -106,7 +106,10 @@ const desktopMenuItemClass =
           <NavigationMenuItem value={`menu-${index}`}>
             {menu.links && menu.links.length > 0 ? (
               <>
-                <NavigationMenuTrigger class={desktopMenuItemClass}>
+                <NavigationMenuTrigger
+                  class={desktopMenuItemClass}
+                  href={menu.href}
+                >
                   {menu.text}
                 </NavigationMenuTrigger>
                 <NavigationMenuContent>
@@ -122,10 +125,7 @@ const desktopMenuItemClass =
                 </NavigationMenuContent>
               </>
             ) : (
-              <NavigationMenuLink
-                class={desktopMenuItemClass}
-                href={menu.href}
-              >
+              <NavigationMenuLink class={desktopMenuItemClass} href={menu.href}>
                 {menu.text}
               </NavigationMenuLink>
             )}
@@ -191,14 +191,17 @@ const desktopMenuItemClass =
               {menu.links && menu.links.length > 0 ? (
                 <Collapsible class="group">
                   <CollapsibleTrigger>
-                    <SidebarMenuButton
-                      as="div"
-                      class="h-10 w-full rounded-md text-xl"
-                    >
-                      <span class="truncate">{menu.text}</span>
+                    <SidebarMenuButton as="div" class="h-10 rounded-md text-xl">
+                      {menu.href ? (
+                        <a class="truncate" href={menu.href}>
+                          {menu.text}
+                        </a>
+                      ) : (
+                        <span class="truncate">{menu.text}</span>
+                      )}
                       <Icon
                         name="chevron-down"
-                        class="ml-auto text-muted-foreground transition-transform duration-200 ease-out group-open:rotate-180"
+                        class="text-muted-foreground ml-auto transition-transform duration-200 ease-out group-open:rotate-180"
                         aria-hidden="true"
                       />
                     </SidebarMenuButton>

--- a/src/components/ui/navigation-menu/navigation-menu-trigger.astro
+++ b/src/components/ui/navigation-menu/navigation-menu-trigger.astro
@@ -7,15 +7,22 @@ import { cn } from "@/lib/utils"
 
 import navigationMenuTriggerStyle from "./navigation-menu-trigger-style"
 
-type Props = HTMLAttributes<"button"> &
-  VariantProps<typeof navigationMenuTriggerStyle>
+type Props = VariantProps<typeof navigationMenuTriggerStyle> &
+  HTMLAttributes<"button"> &
+  HTMLAttributes<"a"> & {
+    as?: "a" | "button"
+    href?: string
+  }
 
-const { class: className, ...props } = Astro.props
+const { class: className, as, href, ...props } = Astro.props
+
+const Comp = as || (href ? "a" : "button")
 ---
 
-<button
+<Comp
   data-slot="navigation-menu-trigger"
   class={cn(navigationMenuTriggerStyle(), "group", className)}
+  href={href}
   {...props}
 >
   <slot />
@@ -24,4 +31,4 @@ const { class: className, ...props } = Astro.props
     class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]/navigation-menu-trigger:rotate-180"
     aria-hidden="true"
   />
-</button>
+</Comp>


### PR DESCRIPTION
Allow top-level nav items that have submenus to link to their parent page. Pass href to the navigation menu trigger and make the mobile parent label a link when provided, while keeping hover dropdown behavior intact.